### PR TITLE
Upgrade compat to scarthgap and fix build issues

### DIFF
--- a/agl_services_build/yocto-layer/meta-google/conf/layer.conf
+++ b/agl_services_build/yocto-layer/meta-google/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_PRIORITY_meta-google = "6"
 
 LAYERDEPENDS_meta-google = "clang-layer"
 
-LAYERSERIES_COMPAT_meta-google = "kirkstone"
+LAYERSERIES_COMPAT_meta-google = "kirkstone scarthgap"

--- a/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/google-trout-agl-services-source_0.1.bb
+++ b/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/google-trout-agl-services-source_0.1.bb
@@ -1,5 +1,7 @@
 SUMMARY = "Source code of Trout AGL Services"
 
+SRCREV_FORMAT = "default"
+
 deltask do_configure
 deltask do_compile
 deltask do_install

--- a/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/google-trout-agl-services_0.1.bb
+++ b/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/google-trout-agl-services_0.1.bb
@@ -2,6 +2,8 @@ DESCRIPTION = "Android Automotive OS Virtualization - AGL Services"
 
 TOOLCHAIN = "clang"
 
+SRCREV_FORMAT = "default"
+
 DEPENDS += "\
     google-trout-grpc-utils-native \
     systemd \

--- a/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/google-trout-grpc-utils-native_0.1.bb
+++ b/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/google-trout-grpc-utils-native_0.1.bb
@@ -2,6 +2,8 @@ DESCRIPTION = "Native GRPC Build utilities"
 
 DEPENDS += "go-native"
 
+SRCREV_FORMAT = "default"
+
 TROUT_target_install = "\
     protoc:aprotoc \
     grpc_cpp_plugin:protoc-gen-grpc-cpp-plugin \


### PR DESCRIPTION
Added scarthgap to compatibility layers and fixed SCM errors while building AGL components:
"The SRCREV_FORMAT variable must be set when multiple SCMs are used."