### PR TITLE
Override trout cmdline

### DIFF
--- a/xenvm_trout_arm64/BoardConfig.mk
+++ b/xenvm_trout_arm64/BoardConfig.mk
@@ -41,6 +41,24 @@ BOARD_BOOTCONFIG += androidboot.hardware.gralloc=minigbm
 BOARD_BOOTCONFIG += androidboot.hardware.egl=mesa androidboot.boot_devices=33000000.pcie
 BOARD_BOOTCONFIG += androidboot.openthread_node_id=1
 
+# Reuse trout androidboot properties
+BOARD_BOOTCONFIG += androidboot.hardware=cutf_cvm
+BOARD_BOOTCONFIG += androidboot.serialno=CUTTLEFISHCVD01
+BOARD_BOOTCONFIG += androidboot.cf_devcfg=1
+
+# Set GPU properties
+BOARD_BOOTCONFIG += androidboot.cpuvulkan.version=0
+
+# Add WiFi configuration for VirtWifi network
+BOARD_BOOTCONFIG += androidboot.wifi_mac_prefix=5554
+
+# Override trout cmdline
+BOARD_KERNEL_CMDLINE = enforcing=0
+BOARD_KERNEL_CMDLINE += mac80211_hwsim.radios=0
+BOARD_KERNEL_CMDLINE += audit=1
+BOARD_KERNEL_CMDLINE += panic=-1
+BOARD_KERNEL_CMDLINE += 8250.nr_uarts=1
+
 BOARD_VENDOR_SEPOLICY_DIRS += device/google/cuttlefish/shared/virgl/sepolicy
 
 # Use virgl and mesa3d upstream


### PR DESCRIPTION
Override trout cmdline to get rid of the
androidboot* properties in it.