### PR TITLE
google-trout-agl-services: fix invalid dependency

### DIFF
--- a/agl_services_build/yocto-layer/meta-google/recipes-trout/images/core-image-weston/google-overlay/etc/systemd/system/dumpstate_grpc_server.service
+++ b/agl_services_build/yocto-layer/meta-google/recipes-trout/images/core-image-weston/google-overlay/etc/systemd/system/dumpstate_grpc_server.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Android Dumpstate GRPC Server
 
-Wants=coqos-virtio-vsock.service
-After=coqos-virtio-vsock.service
+Wants=multi-user.target
+After=multi-user.target
 
 [Service]
 ExecStart=/usr/bin/dumpstate_grpc_server -server_addr vsock:2:9310

--- a/agl_services_build/yocto-layer/meta-google/recipes-trout/images/core-image-weston/google-overlay/etc/systemd/system/gnss_replay.service
+++ b/agl_services_build/yocto-layer/meta-google/recipes-trout/images/core-image-weston/google-overlay/etc/systemd/system/gnss_replay.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Mock GNSS Host Agent
-After=coqos-virtio-console.service
+After=multi-user.target
 
 [Service]
 ExecStartPre=/bin/sh -c 'while [ ! -e /run/gnss-uart ]; do sleep 0.2; done'

--- a/agl_services_build/yocto-layer/meta-google/recipes-trout/images/core-image-weston/google-overlay/etc/systemd/system/vehicle_hal_grpc_server.service
+++ b/agl_services_build/yocto-layer/meta-google/recipes-trout/images/core-image-weston/google-overlay/etc/systemd/system/vehicle_hal_grpc_server.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Android Vehicle HAL GRPC Server
 
-Wants=coqos-virtio-vsock.service
-After=coqos-virtio-vsock.service
+Wants=multi-user.target
+After=multi-user.target
 
 [Service]
 ExecStart=/usr/bin/vehicle_hal_grpc_server -server_cid 2 -server_port 9210 -power_state_file /tmp/power_state_marker -power_state_socket /tmp/power_state_socket


### PR DESCRIPTION
The coqos-virtio-console.service is not present in the system. Ensure services start after multi-user.target.