### PR TITLE
dfw.sh: insert disfwk_fe KM via modprobe

### DIFF
--- a/bin/dfw.sh
+++ b/bin/dfw.sh
@@ -6,5 +6,5 @@ echo start > /sys/class/remoteproc/remoteproc0/state
 log -t dfw "remote proc started ..."
 # WA: need to be sure that Taurus initialization is complete before starting KM
 sleep 2
-insmod /vendor/lib/modules/disfwk_fe.ko
+modprobe -d /vendor/lib/modules/ disfwk_fe
 log -t dfw "disfwk_fe starting ..."


### PR DESCRIPTION
Edit display framework launch script to start using the modprobe instead of insmod for kernel module loading. It allows to pass configuration variables (e.g. disfwk_fe.modeX=1920x1080@60) directly through the Android kernel command line.