### PR TITLE
trout: disbale user UI notification

### DIFF
--- a/rro_overlay/CarServiceOverlay/res/values/config.xml
+++ b/rro_overlay/CarServiceOverlay/res/values/config.xml
@@ -117,4 +117,11 @@
         <item>car_telemetry_service</item>
     </string-array>
 
+    <!-- Specifies notice UI that will be launched when user starts a car or do user
+     switching. It is recommended to use dialog with at least TYPE_APPLICATION_OVERLAY window
+     type to show the UI regardless of activity launches. Target package will be auto-granted
+     necessary permission for TYPE_APPLICATION_OVERLAY window type. The UI package should
+     resolve permission by itself to use any higher priority window type.
+     Setting this string to empty will disable the feature. -->
+    <string name="config_userNoticeUiService" translatable="false"></string>
 </resources>

--- a/rro_overlay/CarServiceOverlay/res/xml/overlays.xml
+++ b/rro_overlay/CarServiceOverlay/res/xml/overlays.xml
@@ -18,7 +18,7 @@
     <item target="array/config_occupant_zones" value="@array/config_occupant_zones" />
     <item target="array/config_occupant_display_mapping" value="@array/config_occupant_display_mapping" />
     <item target="bool/enableProfileUserAssignmentForMultiDisplay" value="@bool/enableProfileUserAssignmentForMultiDisplay" />
-    <!-- <item target="string/config_userNoticeUiService" value="@string/config_userNoticeUiService" /> -->
+    <item target="string/config_userNoticeUiService" value="@string/config_userNoticeUiService" />
     <!-- <item target="string/config_userPickerActivity" value="@string/config_userPickerActivity" /> -->
     <!-- <item target="bool/enablePassengerSupport" value="@bool/enablePassengerSupport" /> -->
     <item target="string/activityAllowlist" value="@string/activityAllowlist" />


### PR DESCRIPTION
The default notification only indicates the possibility of notifying the user with some text and explains how to do it. Disable the default user UI notification until a custom requirement appears.


Reviewed-by: Dmytro Terletskyi <dmytro_terletskyi@epam.com>