### PR TITLE
agl-services: yocto-layer: fix dumpstate_server symlink

### DIFF
--- a/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/sources.inc
+++ b/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/sources.inc
@@ -47,7 +47,7 @@ SRC_SYMLINKS = "\
    device/google/trout/agl_services_build/cmake:cmake \
    device/google/trout/agl_services_build/toolchain:toolchain \
    device/google/trout/hal/audiocontrol:audiocontrol \
-   device/google/trout/hal/dumpstate/1.1:dumpstate_server \
+   device/google/trout/hal/dumpstate/aidl/1.0:dumpstate_server \
    device/google/trout/hal/vehicle/2.0:vehicle_hal_server \
    device/google/trout/hal/common/agl/watchdog:watchdog_test_server \
    hardware/interfaces/automotive/vehicle/2.0/default:third_party/default_native_vehicle_hal \


### PR DESCRIPTION
The dumpstate HAL moved from HIDL (1.1) to AIDL (aidl/1.0) in trout android-17.0.0_r1. Update SRC_SYMLINKS accordingly to fix do_configure failure (missing dumpstate_server/agl_build directory).