### PR TITLE
meta-google: update layer to Yocto Wrynose

### DIFF
--- a/agl_services_build/yocto-layer/meta-google/conf/layer.conf
+++ b/agl_services_build/yocto-layer/meta-google/conf/layer.conf
@@ -9,4 +9,4 @@ BBFILE_PRIORITY_meta-google = "6"
 
 LAYERDEPENDS_meta-google = "clang-layer"
 
-LAYERSERIES_COMPAT_meta-google = "kirkstone scarthgap"
+LAYERSERIES_COMPAT_meta-google = "wrynose"

--- a/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/common.inc
+++ b/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/common.inc
@@ -7,7 +7,7 @@ do_fetch[noexec] = "1"
 deltask do_unpack
 deltask do_patch
 
-S = "${TMPDIR}/work-shared/google-trout-agl-services-source/${PV}-${PR}/${FETCH_CODE_PREFIX}"
+S = "${TMPDIR}/work-shared/google-trout-agl-services-source/${PV}-${PR}/sources/${FETCH_CODE_PREFIX}"
 
 do_configure[depends] += "google-trout-agl-services-source:do_patch"
 do_populate_lic[depends] += "google-trout-agl-services-source:do_unpack"

--- a/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/google-trout-agl-services_0.1.bb
+++ b/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/google-trout-agl-services_0.1.bb
@@ -8,6 +8,10 @@ TARGET_CFLAGS:append = " -Wno-error=array-parameter"
 TARGET_CXXFLAGS:append = " -Wno-error=array-parameter"
 TARGET_CFLAGS:append = " -Wno-error=unused-but-set-variable"
 TARGET_CXXFLAGS:append = " -Wno-error=deprecated-declarations"
+TARGET_CFLAGS:append = " -Wno-error=incompatible-pointer-types-discards-qualifiers"
+TARGET_CXXFLAGS:append = " -Wno-error=incompatible-pointer-types-discards-qualifiers"
+
+EXTRA_OECMAKE += "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
 
 SRCREV_FORMAT = "default"
 

--- a/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/google-trout-grpc-utils-native_0.1.bb
+++ b/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/google-trout-grpc-utils-native_0.1.bb
@@ -9,6 +9,8 @@ TROUT_target_install = "\
     grpc_cpp_plugin:protoc-gen-grpc-cpp-plugin \
 "
 
+EXTRA_OECMAKE += "-DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+
 require common.inc
 
 inherit native

--- a/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/sources.inc
+++ b/agl_services_build/yocto-layer/meta-google/recipes-trout/agl-services/sources.inc
@@ -13,7 +13,7 @@ DEFAULT_REVISION = "s-v2-fs-release"
 
 FETCH_CODE_PREFIX = "src"
 
-S = "${WORKDIR}/${FETCH_CODE_PREFIX}"
+S = "${UNPACKDIR}/${FETCH_CODE_PREFIX}"
 
 # Pull the source from git server remote/name to path
 def trout_git_uri(d, remote, name, path, revision):


### PR DESCRIPTION
The latest meta-renesas layer for Gen5 requires the Yocto Wrynose release. So, as a part of upgrading the layer:

 - update LAYERSERIES_COMPAT_meta-google to wrynose to make the AGL meta-google layer compatible with the rest layers. Kirkstone and Scarthgap versions are outdated for Gen5, so they are dropped from the compatibility list;
 - fix paths to sources according to the new Yocto fetch places;
 - with the Yocto update the toolchain was also updated (newer Clang/GCC) with stricter compilation rules. Suppress the new warnings-as-errors since the target source code is external;
 - set CMAKE_POLICY_VERSION_MINIMUM=3.5 to allow the newer CMake to configure the old third-party projects.